### PR TITLE
Change github build workflow to only run on changes in lib

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'lib/**'
 
 jobs:
   build_and_publish:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 on:
   pull_request:
-    paths:
-      - 'lib/**'
 
 jobs:
   lint_and_test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 on:
   pull_request:
+    paths:
+      - 'lib/**'
 
 jobs:
   lint_and_test:


### PR DESCRIPTION
Configure build github action workflow to only run if we have changes in the `lib` directory, this is important because it allows us to make change more freely to documentation and other directories that are not directly related to the sdk without triggering a new build which leads to a new version.

**Testing this PR:**
I've added a commit `chore: [test action - remove after test] it shouldn't run the test build` which added the path change to the test workflow which should make it so that the test doesn't run for this commit.

Following that I removed the configuration from the test workflow and the test ran for the commit