### PR TITLE
[PLAT-175] Headers not resetting after creating a new justifi request instance

### DIFF
--- a/lib/internal/http.ts
+++ b/lib/internal/http.ts
@@ -97,7 +97,7 @@ export class JustifiRequest {
   constructor(method: RequestMethod, path: string) {
     this.requestUrl = new URL(this.getApiHost() + path);
     this.method = method;
-    this.headers = DEFAULT_HEADERS;
+    this.headers = { ...DEFAULT_HEADERS };
   }
 
   withHeader(key: string, value: string): JustifiRequest {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/justifi-node",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "JustiFi Node SDK",
   "repository": {
     "type": "git",

--- a/tests/lib/http.spec.ts
+++ b/tests/lib/http.spec.ts
@@ -347,4 +347,34 @@ describe("http", () => {
       });
     });
   });
+
+  describe("when executing multiple requests", () => {
+    describe("when setting headers", () => {
+      it("execute the requests correctly", async () => {
+        const mockServer = nock(baseUrl)
+          .get("/first", undefined, { reqheaders: { First: "Request" } })
+          .once()
+          .reply(200, { ok: 200 });
+
+        await new JustifiRequest(RequestMethod.Get, "/first")
+          .withHeader("First", "Request")
+          .execute();
+
+        expect(mockServer.isDone()).toEqual(true);
+        expect(mockServer.pendingMocks()).toHaveLength(0);
+
+        mockServer
+          .get(`/second`, undefined, { reqheaders: { Second: "Request" } })
+          .once()
+          .reply(200, { ok: 200 }),
+
+          await new JustifiRequest(RequestMethod.Get, "/second")
+            .withHeader("Second", "Request")
+            .execute();
+
+        expect(mockServer.isDone()).toEqual(true);
+        expect(mockServer.pendingMocks()).toHaveLength(0);
+      })
+    })
+  })
 });


### PR DESCRIPTION
We were having issues with headers from previous requests being "merged" with headers from a new request which was causing some requests to fail depending on which request was executed previously.

This issue is caused because JS was using the reference to the previous value of the `headers` property instead of creating a new value based of the `DEFAULT_HEADERS`, to solve this issue we force JS to recreate the hash by spreading `DEFAULT_HEADERS` into a new hash.