### PR TITLE
[PLAT-275] Node SDK: Add User-Agent header

### DIFF
--- a/lib/internal/http.ts
+++ b/lib/internal/http.ts
@@ -6,6 +6,7 @@ import {
   BaseError,
   PaginationError,
 } from "./error";
+import { version } from "../../package.json";
 
 export interface PageInfo {
   endCursor: string;
@@ -83,7 +84,8 @@ export type RequestHeaders = { [key: string]: string };
 
 export const DEFAULT_HEADERS = {
   "Content-Type": "application/json",
-  Accept: "application/json",
+  "Accept": "application/json",
+  "User-Agent": `justifi-node-${version}`
 };
 
 export class JustifiRequest {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/justifi-node",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "JustiFi Node SDK",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
+    "resolveJsonModule": true,
     "declaration": true,
     "outDir": "./dist",
     "strict": true,


### PR DESCRIPTION
Add default header `User-Agent: justifi-node-version` (where version is the package version)